### PR TITLE
Add position option to Dialog progress window

### DIFF
--- a/macOS-Dialog-Self-Service.sh
+++ b/macOS-Dialog-Self-Service.sh
@@ -22,6 +22,7 @@ show_install_progress() {
         --icon "/Library/Application Support/Dialog/Dialog.png" \
         --button1disabled \
         --progress 4 \
+        --position bottomright \
         --commandfile "$dialogCommandFile" \
         --moveable --ontop --mini &
 


### PR DESCRIPTION
Sets the Dialog progress window to appear in the bottom right corner by adding the --position bottomright flag.